### PR TITLE
Initial addition of builtin steps

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1832,6 +1832,22 @@ When this builtin is invoked with parameter |v|, the following steps must be run
 
 </div>
 
+<h4 id="js-string-fromCharCodeArray">fromCharCodeArray</h4>
+
+TODO
+
+<h4 id="js-string-intoCharCodeArray">intoCharCodeArray</h4>
+
+TODO
+
+<h4 id="js-string-fromCharCode">fromCharCode</h4>
+
+TODO
+
+<h4 id="js-string-fromCodePoint">fromCodePoint</h4>
+
+TODO
+
 <h4 id="js-string-charCodeAt">charCodeAt</h4>
 
 The type of this function is `(func (param externref i32) (result i32))`.
@@ -1844,6 +1860,29 @@ When this builtin is invoked, the following steps must be run:
 
 </div>
 
+<h4 id="js-string-codePointAt">codePointAt</h4>
+
+TODO
+
+<h4 id="js-string-length">length</h4>
+
+TODO
+
+<h4 id="js-string-concat">concat</h4>
+
+TODO
+
+<h4 id="js-string-substring">substring</h4>
+
+TODO
+
+<h4 id="js-string-equals">equals</h4>
+
+TODO
+
+<h4 id="js-string-compare">compare</h4>
+
+TODO
 
 <h2 id="errors">Error Condition Mappings to JavaScript</h2>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -358,8 +358,8 @@ Note:
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
     1. [=Compile a WebAssembly module|Compile=] |stableBytes| as a WebAssembly module and store the results as |module|.
     1. If |module| is [=error=], return false.
-    1. Let |builtinSetNames| be options["builtins"]
-    1. Let |importedStringModule| be options["importedStringConstants"]
+    1. Let |builtinSetNames| be |options|["builtins"]
+    1. Let |importedStringModule| be |options|["importedStringConstants"]
     1. If [=validate builtins and imported string for a WebAssembly module|validating builtins and imported strings=] for |module| with |builtinSetNames| and |importedStringModule| returns false, return false.
     1. Return true.
 </div>
@@ -390,8 +390,8 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
         1. [=compile a WebAssembly module|Compile the WebAssembly module=] |bytes| and store the result as |module|.
         1. [=Queue a task=] to perform the following steps. If |taskSource| was provided, queue the task on that task source.
             1. If |module| is [=error=], reject |promise| with a {{CompileError}} exception.
-            1. Let |builtinSetNames| be options["builtins"]
-            1. Let |importedStringModule| be options["importedStringConstants"]
+            1. Let |builtinSetNames| be |options|["builtins"]
+            1. Let |importedStringModule| be |options|["importedStringConstants"]
             1. If [=validate builtins and imported string for a WebAssembly module|validating builtins and imported strings=] for |module| with |builtinSetNames| and |importedStringModule| is false, reject |promise| with a {{CompileError}} exception.
             1. Otherwise,
                 1. [=Construct a WebAssembly module object=] from |module|, |bytes|, |builtinSetNames|, |importedStringModule|, and let |moduleObject| be the result.
@@ -686,8 +686,8 @@ interface Module {
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
     1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
     1. If |module| is [=error=], throw a {{CompileError}} exception.
-    1. Let |builtinSetNames| be options["builtins"]
-    1. Let |importedStringModule| be options["importedStringConstants"]
+    1. Let |builtinSetNames| be |options|["builtins"]
+    1. Let |importedStringModule| be |options|["importedStringConstants"]
     1. If [=validate builtins and imported string for a WebAssembly module|validating builtins and imported strings=] for |module| with |builtinSetNames| and |importedStringModule| returns false, throw a {{CompileError}} exception.
     1. Set **this**.\[[Module]] to |module|.
     1. Set **this**.\[[Bytes]] to |stableBytes|.

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -67,6 +67,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: String.prototype.charCodeAt; url: sec-string.prototype.charcodeat
         text: String.prototype.codePointAt; url: sec-string.prototype.codepointat
         text: String.prototype.concat; url: sec-string.prototype.concat
+        text: String.prototype.substring; url: sec-string.prototype.substring
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
@@ -1922,13 +1923,24 @@ When this builtin is invoked with parameters |first| and |second|, the following
 
 1. Let |first| be [=?=] [$UnwrapString$](|first|).
 1. Let |second| be [=?=] [$UnwrapString$](|second|).
-1. Return [=!=] [$Call$]([=String.prototype.concat=], |first|, |second|).
+1. Return [=!=] [$Call$]([=String.prototype.concat=], |first|, &laquo; |second| &raquo;).
 
 </div>
 
 <h4 id="js-string-substring">substring</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param externref i32 i32) (result externref))`.
+
+<div algorithm="js-string-substring">
+When this builtin is invoked with parameters |string|, |start|, and |end|, the following steps must be run:
+
+1. Let |string| be [=?=] [$UnwrapString$](|string|).
+1. Let |length| be the [=string/length=] of |string|.
+1. If |start| > |end| or |start| > |length|
+    1. Return the empty string.
+1. Return [=!=] [$Call$]([=String.prototype.substring=], |string|, &laquo; [=ToJSValue=](|start|), [=ToJSValue=](|end|) &raquo;).
+
+</div>
 
 <h4 id="js-string-equals">equals</h4>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1814,6 +1814,15 @@ The <dfn abstract-op lt="UnwrapString">UnwrapString(|v|)</dfn> abstract operatio
 
 </div>
 
+<div algorithm>
+
+The <dfn abstract-op lt="FromCharCode">FromCharCode(|v|)</dfn> abstract operation, when invoked, performs the following steps:
+
+1. Assert: |v| is of type [=i32=].
+1. Return [=!=] [$Call$]([=String.fromCharCode=], undefined, « [=ToJSValue=](|v|) »).
+
+</div>
+
 <h4 id="js-string-cast">cast</h4>
 
 The |funcType| of this builtin is `(func (param externref) (result externref))`.
@@ -1840,7 +1849,25 @@ When this builtin is invoked with parameter |v|, the following steps must be run
 
 <h4 id="js-string-fromCharCodeArray">fromCharCodeArray</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param (ref null (array (mut i16))) i32 i32) (result externref))`.
+
+<div algorithm="js-string-fromCharCodeArray">
+When this builtin is invoked with parameters |array|, |start|, and |end|, the following steps must be run:
+
+1. If |array| is nul]
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. If |start| > |end| or |end| > [=array_len=](|array|)
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. Let |result| be the empty string
+1. Let |i| be |start|
+1. While |i| < |end|:
+    1. Let |charCode| be [=array_i16_get=](|array|, |i|).
+    1. Let |charCodeString| be [$FromCharCode$](|charCode|).
+    1. Let |result| be the concatenation of |result| and |charCodeString|.
+    1. Set |i| to |i| + 1.
+1. Return |result|
+
+</div>
 
 <h4 id="js-string-intoCharCodeArray">intoCharCodeArray</h4>
 
@@ -1853,7 +1880,7 @@ The |funcType| of this builtin is `(func (param i32) (result externref))`.
 <div algorithm="js-string-fromCharCode">
 When this builtin is invoked with parameter |v|, the following steps must be run:
 
-1. Return [=!=] [$Call$]([=String.fromCharCode=], undefined, « [=ToJSValue=](|v|) »).
+1. Return [$FromCharCode$](|v|).
 
 </div>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -63,6 +63,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: ℤ; url: #ℤ
         text: SameValue; url: sec-samevalue
         text: String.fromCharCode; url: sec-string.fromcharcode
+        text: String.fromCodePoint; url: sec-string.fromcodepoint
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
@@ -1848,13 +1849,22 @@ The |funcType| of this builtin is `(func (param i32) (result externref))`.
 <div algorithm="js-string-fromCharCode">
 When this builtin is invoked with parameter |v|, the following steps must be run:
 
-1. Return [=!=] [=String.fromCharCode=]([=ToJSValue=](|v|)).
+1. Return [=!=] [$Call$]([=String.fromCharCode=], undefined, [=ToJSValue=](|v|)).
 
 </div>
 
 <h4 id="js-string-fromCodePoint">fromCodePoint</h4>
 
 TODO
+
+The |funcType| of this builtin is `(func (param i32) (result externref))`.
+
+<div algorithm="js-string-fromCodePoint">
+When this builtin is invoked with parameter |v|, the following steps must be run:
+
+1. Return [=!=] [$Call$]([=String.fromCodePoint=], undefined, [=ToJSValue=](|v|)).
+
+</div>
 
 <h4 id="js-string-charCodeAt">charCodeAt</h4>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1753,7 +1753,7 @@ To <dfn>validate builtin set names</dfn> with |builtinSetNames|, perform the fol
 </div>
 
 <div algorithm>
-  To <dfn>create a builtin function</dfn> from type |functype| and execution steps |steps|, perform the following steps:
+  To <dfn>create a builtin function</dfn> from type |funcType| and execution steps |steps|, perform the following steps:
 
     1. Let |stored settings| be the <a spec=HTML>incumbent settings object</a>.
     1. Let |hostfunc| be a [=host function=] which executes |steps| when called.
@@ -1769,8 +1769,8 @@ To <dfn>instantiate a builtin set</dfn> with name |builtinSetName|, perform the 
 1. Let |builtins| be the result of [=get the builtins for a builtin set=] |builtinSetName|
 1. Let |exportsObject| be [=!=] [$OrdinaryObjectCreate$](null).
         1. If |externtype| is of the form [=external-type/func=] <var ignore>functype</var>,
-1. [=list/iterate|For each=] (|name|, |funcType|, |algorithm|) of |builtins|,
-    1. Let |funcaddr| be the result fo [=create a builtin function=] with |funcType| and |algorithm|
+1. [=list/iterate|For each=] (|name|, |funcType|, |steps|) of |builtins|,
+    1. Let |funcaddr| be the result fo [=create a builtin function=] with |funcType| and |steps|
     1. Let |func| be the result of creating [=a new Exported Function=] from |funcaddr|.
     1. Let |value| be |func|.
     1. Let |status| be [=!=] [$CreateDataProperty$](|exportsObject|, |name|, |value|).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -62,6 +62,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: 𝔽; url: #𝔽
         text: ℤ; url: #ℤ
         text: SameValue; url: sec-samevalue
+        text: String.fromCharCode; url: sec-string.fromcharcode
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
@@ -1842,7 +1843,14 @@ TODO
 
 <h4 id="js-string-fromCharCode">fromCharCode</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param i32) (result externref))`.
+
+<div algorithm="js-string-fromCharCode">
+When this builtin is invoked with parameter |v|, the following steps must be run:
+
+1. Return [=!=] [=String.fromCharCode=]([=ToJSValue=](|v|)).
+
+</div>
 
 <h4 id="js-string-fromCodePoint">fromCodePoint</h4>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1853,13 +1853,11 @@ The |funcType| of this builtin is `(func (param i32) (result externref))`.
 <div algorithm="js-string-fromCharCode">
 When this builtin is invoked with parameter |v|, the following steps must be run:
 
-1. Return [=!=] [$Call$]([=String.fromCharCode=], undefined, [=ToJSValue=](|v|)).
+1. Return [=!=] [$Call$]([=String.fromCharCode=], undefined, « [=ToJSValue=](|v|) »).
 
 </div>
 
 <h4 id="js-string-fromCodePoint">fromCodePoint</h4>
-
-TODO
 
 The |funcType| of this builtin is `(func (param i32) (result externref))`.
 
@@ -1868,7 +1866,7 @@ When this builtin is invoked with parameter |v|, the following steps must be run
 
 1. If |v| &gt; 0x10ffff
     1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
-1. Return [=!=] [$Call$]([=String.fromCodePoint=], undefined, [=ToJSValue=](|v|)).
+1. Return [=!=] [$Call$]([=String.fromCodePoint=], undefined, « [=ToJSValue=](|v|) »).
 
 </div>
 
@@ -1883,7 +1881,7 @@ When this builtin is invoked with parameters |string| and |index|, the following
 1. Let |length| be the [=string/length=] of |string|.
 1. If |index| >= |length|
     1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
-1. Return [=!=] [$Call$]([=String.prototype.charCodeAt=], |string|, [=ToJSValue=](|index|)).
+1. Return [=!=] [$Call$]([=String.prototype.charCodeAt=], |string|, « [=ToJSValue=](|index|) »).
 
 </div>
 
@@ -1898,7 +1896,7 @@ When this builtin is invoked with parameters |string| and |index|, the following
 1. Let |length| be the [=string/length=] of |string|.
 1. If |index| >= |length|
     1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
-1. Return [=!=] [$Call$]([=String.prototype.codePointAt=], |string|, [=ToJSValue=](|index|)).
+1. Return [=!=] [$Call$]([=String.prototype.codePointAt=], |string|, « [=ToJSValue=](|index|) »).
 
 </div>
 
@@ -1923,7 +1921,7 @@ When this builtin is invoked with parameters |first| and |second|, the following
 
 1. Let |first| be [=?=] [$UnwrapString$](|first|).
 1. Let |second| be [=?=] [$UnwrapString$](|second|).
-1. Return [=!=] [$Call$]([=String.prototype.concat=], |first|, &laquo; |second| &raquo;).
+1. Return [=!=] [$Call$]([=String.prototype.concat=], |first|, « |second| »).
 
 </div>
 
@@ -1938,7 +1936,7 @@ When this builtin is invoked with parameters |string|, |start|, and |end|, the f
 1. Let |length| be the [=string/length=] of |string|.
 1. If |start| > |end| or |start| > |length|
     1. Return the empty string.
-1. Return [=!=] [$Call$]([=String.prototype.substring=], |string|, &laquo; [=ToJSValue=](|start|), [=ToJSValue=](|end|) &raquo;).
+1. Return [=!=] [$Call$]([=String.prototype.substring=], |string|, « [=ToJSValue=](|start|), [=ToJSValue=](|end|) »).
 
 </div>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1797,13 +1797,25 @@ To <dfn>validate an import for builtins</dfn> with |import|, enabled builtins |b
 
 String builtins adapt the interface of the String builtin object. The import name for this set is `wasm:js-string`.
 
-<div algorithm="js-string-unwrapString">
+<h4 id="builtins-js-string-abstract-ops">Abstract operations</h4>
+<div algorithm>
 
-The <dfn>unwrapString(|v|)</dfn> method, when invoked, performs the following steps:
+The <dfn abstract-op lt="UnwrapString">UnwrapString(|v|)</dfn> abstract operation, when invoked, performs the following steps:
 
-1. If [=Type=](|v|) is not String
+1. If [=Type=](|v|) is not [=String=]
     1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
 1. Return |v|
+
+</div>
+
+<h4 id="js-string-cast">cast</h4>
+
+The |funcType| of this builtin is `(func (param externref) (result externref))`.
+
+<div algorithm="js-string-cast">
+When this builtin is invoked with parameter |v|, the following steps must be run:
+
+1. Return [=?=] [$UnwrapString$](|v|)
 
 </div>
 
@@ -1814,7 +1826,7 @@ The type of this function is `(func (param externref i32) (result i32))`.
 <div algorithm="js-string-charCodeAt">
 When this builtin is invoked, the following steps must be run:
 
-1. Let |string| be [$unwrapString$](param0)
+1. Let |string| be [$UnwrapString$](param0)
 1. TODO
 
 </div>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -62,6 +62,8 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: 𝔽; url: #𝔽
         text: ℤ; url: #ℤ
         text: SameValue; url: sec-samevalue
+        text: IsStrictlyEqual; url: sec-isstrictlyequal
+        text: IsLessThan; url: sec-islessthan
         text: String.fromCharCode; url: sec-string.fromcharcode
         text: String.fromCodePoint; url: sec-string.fromcodepoint
         text: String.prototype.charCodeAt; url: sec-string.prototype.charcodeat
@@ -2007,11 +2009,41 @@ When this builtin is invoked with parameters |string|, |start|, and |end|, the f
 
 <h4 id="js-string-equals">equals</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param externref externref) (result i32))`.
+
+Note: Explicitly allow null strings to be compared for equality as that is meaningful.
+
+<div algorithm="js-string-equals">
+
+When this builtin is invoked with parameters |first| and |second|, the following steps must be run:
+
+1. If |first| is not null and [=Type=](|first|) is not [=String=]
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. If |second| is not null and [=Type=](|second|) is not [=String=]
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. If [=!=] [=IsStrictlyEqual=](|first|, |second|) is true
+    1. Return 1.
+1. Return 0.
+
+</div>
 
 <h4 id="js-string-compare">compare</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param externref externref) (result i32))`.
+
+<div algorithm="js-string-compare">
+
+When this builtin is invoked with parameters |first| and |second|, the following steps must be run:
+
+1. Let |first| be [=?=] [$UnwrapString$](|first|).
+1. Let |second| be [=?=] [$UnwrapString$](|second|).
+1. If [=!=] [=IsStrictlyEqual=](|first|, |second|) is true
+    1. Return 0.
+1. If [=!=] [=IsLessThan=](|first|, |second|, true) is true
+    1. Return -1.
+1. Return 1.
+
+</div>
 
 <h2 id="errors">Error Condition Mappings to JavaScript</h2>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1823,6 +1823,15 @@ The <dfn abstract-op lt="FromCharCode">FromCharCode(|v|)</dfn> abstract operatio
 
 </div>
 
+<div algorithm>
+
+The <dfn abstract-op lt="CharCodeAt ">CharCodeAt(|string|, |index|)</dfn> abstract operation, when invoked, performs the following steps:
+
+1. Assert: |index| is of type [=i32=].
+1. Return [=!=] [$Call$]([=String.prototype.charCodeAt=], |string|, « [=ToJSValue=](|index|) »).
+
+</div>
+
 <h4 id="js-string-cast">cast</h4>
 
 The |funcType| of this builtin is `(func (param externref) (result externref))`.
@@ -1876,7 +1885,31 @@ When this builtin is invoked with parameters |array|, |start|, and |end|, the fo
 
 <h4 id="js-string-intoCharCodeArray">intoCharCodeArray</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param externref (ref null (array (mut i16))) i32) (result i32))`.
+
+Note: This function only takes a mutable i16 array defined in its own recursion group.
+If this is an issue for toolchains, we can look into how to relax the function type
+while still maintaining good performance.
+
+<div algorithm="js-string-intoCharCodeArray">
+When this builtin is invoked with parameters |string|, |array|, and |start|, the following steps must be run:
+
+1. If |array| is null
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. Let |string| be [=?=] [$UnwrapString$](|string|).
+1. Let |stringLength| be the [=string/length=] of |string|.
+1. Let |arrayLength| be the number of elements in |array|.
+1. If |start| + |length| > |arrayLength|
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. Let |i| be 0.
+1. While |i| < |stringLength|:
+    1. Let |charCode| be [$CharCodeAt$](|string|, |i|).
+    1. Set the element at index |start| + |i| in |array| to [=ToWebAssemblyValue=](|charCode|).
+    1. Set |i| to |i| + 1.
+1. Return |stringLength|.
+
+</div>
+
 
 <h4 id="js-string-fromCharCode">fromCharCode</h4>
 
@@ -1913,7 +1946,7 @@ When this builtin is invoked with parameters |string| and |index|, the following
 1. Let |length| be the [=string/length=] of |string|.
 1. If |index| >= |length|
     1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
-1. Return [=!=] [$Call$]([=String.prototype.charCodeAt=], |string|, « [=ToJSValue=](|index|) »).
+1. Return [$CharCodeAt$](|string|, |index|).
 
 </div>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1884,7 +1884,15 @@ TODO
 
 <h4 id="js-string-length">length</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param externref) (result i32))`.
+
+<div algorithm="js-string-length">
+When this builtin is invoked with parameter |v|, the following steps must be run:
+
+1. Let |string| be [=?=] [$UnwrapString$](|v|).
+1. Return the [=string/length=] of |string|.
+
+</div>
 
 <h4 id="js-string-concat">concat</h4>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1819,6 +1819,19 @@ When this builtin is invoked with parameter |v|, the following steps must be run
 
 </div>
 
+<h4 id="js-string-test">test</h4>
+
+The |funcType| of this builtin is `(func (param externref) (result i32))`.
+
+<div algorithm="js-string-test">
+When this builtin is invoked with parameter |v|, the following steps must be run:
+
+1. If [=Type=](|v|) is not [=String=]
+    1. Return 0
+1. Return 1
+
+</div>
+
 <h4 id="js-string-charCodeAt">charCodeAt</h4>
 
 The type of this function is `(func (param externref i32) (result i32))`.

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1851,21 +1851,26 @@ When this builtin is invoked with parameter |v|, the following steps must be run
 
 The |funcType| of this builtin is `(func (param (ref null (array (mut i16))) i32 i32) (result externref))`.
 
+Note: This function only takes a mutable i16 array defined in its own recursion group.
+If this is an issue for toolchains, we can look into how to relax the function type
+while still maintaining good performance.
+
 <div algorithm="js-string-fromCharCodeArray">
 When this builtin is invoked with parameters |array|, |start|, and |end|, the following steps must be run:
 
-1. If |array| is nul]
+1. If |array| is null
     1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
-1. If |start| > |end| or |end| > [=array_len=](|array|)
+1. Let |length| be the number of elements in |array|.
+1. If |start| > |end| or |end| > |length|
     1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
-1. Let |result| be the empty string
-1. Let |i| be |start|
+1. Let |result| be the empty string.
+1. Let |i| be |start|.
 1. While |i| < |end|:
-    1. Let |charCode| be [=array_i16_get=](|array|, |i|).
+    1. Let |charCode| be the value of the element stored at index |i| in |array|.
     1. Let |charCodeString| be [$FromCharCode$](|charCode|).
     1. Let |result| be the concatenation of |result| and |charCodeString|.
     1. Set |i| to |i| + 1.
-1. Return |result|
+1. Return |result|.
 
 </div>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -64,6 +64,8 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: SameValue; url: sec-samevalue
         text: String.fromCharCode; url: sec-string.fromcharcode
         text: String.fromCodePoint; url: sec-string.fromcodepoint
+        text: String.prototype.charCodeAt; url: sec-string.prototype.charcodeat
+        text: String.prototype.codePointAt; url: sec-string.prototype.codepointat
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
@@ -1862,6 +1864,8 @@ The |funcType| of this builtin is `(func (param i32) (result externref))`.
 <div algorithm="js-string-fromCodePoint">
 When this builtin is invoked with parameter |v|, the following steps must be run:
 
+1. If |v| &gt; 0x10ffff
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
 1. Return [=!=] [$Call$]([=String.fromCodePoint=], undefined, [=ToJSValue=](|v|)).
 
 </div>
@@ -1871,16 +1875,30 @@ When this builtin is invoked with parameter |v|, the following steps must be run
 The type of this function is `(func (param externref i32) (result i32))`.
 
 <div algorithm="js-string-charCodeAt">
-When this builtin is invoked, the following steps must be run:
+When this builtin is invoked with parameters |string| and |index|, the following steps must be run:
 
-1. Let |string| be [$UnwrapString$](param0)
-1. TODO
+1. Let |string| be [=?=] [$UnwrapString$](|string|).
+1. Let |length| be the [=string/length=] of |string|.
+1. If |index| >= |length|
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. Return [=!=] [$Call$]([=String.prototype.charCodeAt=], |string|, [=ToJSValue=](|index|)).
 
 </div>
 
 <h4 id="js-string-codePointAt">codePointAt</h4>
 
-TODO
+The type of this function is `(func (param externref i32) (result i32))`.
+
+<div algorithm="js-string-codePointAt">
+When this builtin is invoked with parameters |string| and |index|, the following steps must be run:
+
+1. Let |string| be [=?=] [$UnwrapString$](|string|).
+1. Let |length| be the [=string/length=] of |string|.
+1. If |index| >= |length|
+    1. Throw a {{RuntimeError}} exception. TODO: this needs to not be catchable, like a trap.
+1. Return [=!=] [$Call$]([=String.prototype.codePointAt=], |string|, [=ToJSValue=](|index|)).
+
+</div>
 
 <h4 id="js-string-length">length</h4>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -66,6 +66,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: String.fromCodePoint; url: sec-string.fromcodepoint
         text: String.prototype.charCodeAt; url: sec-string.prototype.charcodeat
         text: String.prototype.codePointAt; url: sec-string.prototype.codepointat
+        text: String.prototype.concat; url: sec-string.prototype.concat
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
@@ -1914,7 +1915,16 @@ When this builtin is invoked with parameter |v|, the following steps must be run
 
 <h4 id="js-string-concat">concat</h4>
 
-TODO
+The |funcType| of this builtin is `(func (param externref externref) (result externref))`.
+
+<div algorithm="js-string-concat">
+When this builtin is invoked with parameters |first| and |second|, the following steps must be run:
+
+1. Let |first| be [=?=] [$UnwrapString$](|first|).
+1. Let |second| be [=?=] [$UnwrapString$](|second|).
+1. Return [=!=] [$Call$]([=String.prototype.concat=], |first|, |second|).
+
+</div>
 
 <h4 id="js-string-substring">substring</h4>
 


### PR DESCRIPTION
Adds steps for all string builtins.

Several different approaches are taken for referencing JS
operations, depending on what the JS spec exposes:
- Where there's already an abstract operation of the right form, reference that directly
- Where there's only a JS function, use the `Call` operation and a reference to the function

Also clean up some of the underlying infra:
- Make `UnwrapString` an abstract op
- Try to use the same names for things in more places
- Fix a few Bikeshed warnings

Major TODOs include:
- How to treat errors as traps for Wasm callers
- Whether to do something more formal for the builtins which operate on `i16` arrays 