### PR TITLE
Fix null-handling for `equals` in test and polyfill

### DIFF
--- a/test/js-api/js-string/basic.tentative.any.js
+++ b/test/js-api/js-string/basic.tentative.any.js
@@ -168,7 +168,7 @@ function assert_throws_if(func, shouldThrow, constructor) {
   } catch (e) {
     error = e;
   }
-  assert_equals(error !== null, shouldThrow);
+  assert_equals(error !== null, shouldThrow, "shouldThrow mismatch");
   if (shouldThrow && error !== null) {
     assert_true(error instanceof constructor);
   }
@@ -275,7 +275,7 @@ test(() => {
         builtinExports['equals'],
         polyfillExports['equals'],
         a, a
-      ), !isString, WebAssembly.RuntimeError);
+      ), a !== null && !isString, WebAssembly.RuntimeError);
 
     assert_throws_if(() => assert_same_behavior(
         builtinExports['compare'],

--- a/test/js-api/js-string/polyfill.js
+++ b/test/js-api/js-string/polyfill.js
@@ -155,8 +155,8 @@ this.polyfillImports = {
     return string.substring(startIndex, endIndex);
   },
   equals: (stringA, stringB) => {
-    throwIfNotString(stringA);
-    throwIfNotString(stringB);
+    if (stringA !== null) throwIfNotString(stringA);
+    if (stringB !== null) throwIfNotString(stringB);
     return stringA === stringB;
   },
   compare: (stringA, stringB) => {


### PR DESCRIPTION
Equals specifically allows null inputs. Update the JS API tests and the polyfill to match.