### PR TITLE
Support polyfill fallbacks within builtin modules

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -459,7 +459,7 @@ To <dfn>instantiate imported strings</dfn> with module |module| and |importedStr
         1. [=map/set|Set=] |builtinOrStringImports|[|importedStringModule|] to |exportsObject|
     1. Let |imports| be « ».
     1. [=list/iterate|For each=] (|moduleName|, |componentName|, |externtype|) of [=module_imports=](|module|),
-        1. If |builtinOrStringImports| [=map/exist|contains=] |moduleName|,
+        1. If |builtinOrStringImports| [=map/exist|contains=] |moduleName| and |builtinOrStringImports|[|moduleName|] [=map/exist|contains=] |componentName|,
             1. Let |o| be |builtinOrStringImports|[|moduleName|]
         1. Else,
             1. Let |o| be [=?=] [$Get$](|importObject|, |moduleName|).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -461,7 +461,7 @@ To <dfn>instantiate imported strings</dfn> with module |module| and |importedStr
     1. [=list/iterate|For each=] (|moduleName|, |componentName|, |externtype|) of [=module_imports=](|module|),
         1. If |builtinOrStringImports| [=map/exist|contains=] |moduleName|,
             1. Let |o| be |builtinOrStringImports|[|moduleName|].
-            1. If |o| [=is not an Object=] of if |o| [=map/exist|does not contain=] |componentName|,
+            1. If |o| [=is not an Object=] or if |o| [=map/exist|does not contain=] |componentName|,
                 1. Set |o| to [=?=] [$Get$](|importObject|, |moduleName|).
         1. Else,
             1. Let |o| be [=?=] [$Get$](|importObject|, |moduleName|).

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -459,8 +459,10 @@ To <dfn>instantiate imported strings</dfn> with module |module| and |importedStr
         1. [=map/set|Set=] |builtinOrStringImports|[|importedStringModule|] to |exportsObject|
     1. Let |imports| be « ».
     1. [=list/iterate|For each=] (|moduleName|, |componentName|, |externtype|) of [=module_imports=](|module|),
-        1. If |builtinOrStringImports| [=map/exist|contains=] |moduleName| and |builtinOrStringImports|[|moduleName|] [=map/exist|contains=] |componentName|,
-            1. Let |o| be |builtinOrStringImports|[|moduleName|]
+        1. If |builtinOrStringImports| [=map/exist|contains=] |moduleName|,
+            1. Let |o| be |builtinOrStringImports|[|moduleName|].
+            1. If |o| [=is not an Object=] of if |o| [=map/exist|does not contain=] |componentName|,
+                1. Set |o| to [=?=] [$Get$](|importObject|, |moduleName|).
         1. Else,
             1. Let |o| be [=?=] [$Get$](|importObject|, |moduleName|).
         1. If |o| [=is not an Object=], throw a {{TypeError}} exception.


### PR DESCRIPTION
Currently my reading of the spec as written is that when string builtins are enabled, the read the imports algorithm will fail if a function is imported from `wasm:js-strings` that does not exist, instead of falling back to the `importsObj` for that specific function only.

This updates the algorithm to instead allow falling back to the imports object on a per-named-import basis.